### PR TITLE
Interactive library for the interpreter

### DIFF
--- a/bin/cutlet.cpp
+++ b/bin/cutlet.cpp
@@ -156,12 +156,21 @@ int main(int argc, char *argv[]) {
          * by line.
          */
 
-        interpreter.import("shell");
+        interpreter.import("interactive");
         std::function<std::istream &()> cmdline_stream =
           interpreter.symbol<std::istream &(*)()>("cmdline_stream");
         std::istream &cin = cmdline_stream();
 
-        compiled = interpreter(cin, "_stdin_", true);
+        while (cin and not interpreter.done()) {
+          try {
+            compiled = interpreter(cin, "_stdin_", true);
+          } catch (cutlet::exception &err) {
+            std::cerr << "ERROR: " << err.what() << std::endl;
+            for (int i = 0; i < interpreter.frames(); i++) {
+              std::cerr << interpreter.frame(i) << std::endl;
+            }
+          }
+        }
 
       } else {
         // This appears to be piped in so do everything at once.

--- a/bin/cutlet.cpp
+++ b/bin/cutlet.cpp
@@ -157,9 +157,9 @@ int main(int argc, char *argv[]) {
          */
 
         interpreter.import("interactive");
-        std::function<std::istream &()> cmdline_stream =
-          interpreter.symbol<std::istream &(*)()>("cmdline_stream");
-        std::istream &cin = cmdline_stream();
+        std::function<std::istream &()> interactive_stream =
+          interpreter.symbol<std::istream &(*)()>("interactive_stream");
+        std::istream &cin = interactive_stream();
 
         while (cin and not interpreter.done()) {
           try {
@@ -169,6 +169,7 @@ int main(int argc, char *argv[]) {
             for (int i = 0; i < interpreter.frames(); i++) {
               std::cerr << interpreter.frame(i) << std::endl;
             }
+            interpreter.state(cutlet::frame::FS_RUNNING);
           }
         }
 

--- a/configure.ac
+++ b/configure.ac
@@ -62,11 +62,11 @@ esac
 
 PKG_CHECK_MODULES([READLINE], [readline >= 8],
                   [AC_DEFINE(HAVE_READLINE_H)],
-                  [AC_MSG_ERROR([ncurses library not found])])
+                  [AC_MSG_ERROR([readline library not found])])
 
 # Checks for header files.
 AC_CHECK_HEADER([getopt.h], [],
-                            [AC_MSG_ERROR([Missing header getopt.h])])
+                [AC_MSG_ERROR([Missing header getopt.h])])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_HEADER_STDBOOL

--- a/include/cutlet
+++ b/include/cutlet
@@ -350,6 +350,8 @@ namespace cutlet {
   class DECLSPEC sandbox {
   public:
     using pointer = std::shared_ptr<sandbox>;
+    using const_citerator =
+      std::map<std::string, component::pointer>::const_iterator;
 
     sandbox();
     sandbox(const sandbox &other) = delete;
@@ -364,6 +366,9 @@ namespace cutlet {
     void clear();
 
     component::pointer get(const std::string &name) const;
+    const std::map<std::string, component::pointer> &components() const {
+      return _components;
+    }
 
     cutlet::variable::pointer variable(interpreter &interp,
                                        const std::string &name);

--- a/libs/Makefile.am
+++ b/libs/Makefile.am
@@ -1,5 +1,6 @@
 # Shared libraries
-pkglib_LTLIBRARIES = stdlib.la threading.la oo.la shell.la debugger.la
+pkglib_LTLIBRARIES = stdlib.la threading.la oo.la interactive.la shell.la \
+	debugger.la
 scriptlibdir = $(pkglibdir)
 scriptlib_DATA = testsuite.cutlet
 
@@ -20,9 +21,14 @@ oo_la_CPPFLAGS = -I @top_srcdir@/include
 oo_la_LIBADD = ../src/libcutlet.la
 oo_la_LDFLAGS = -module -avoid-version -shared
 
+interactive_la_SOURCES = interactive.cpp
+interactive_la_CPPFLAGS = -I @top_srcdir@/include $(READLINE_CFLAGS)
+interactive_la_LIBADD = ../src/libcutlet.la $(READLINE_LIBS)
+interactive_la_LDFLAGS = -module -avoid-version -shared
+
 shell_la_SOURCES = shell.cpp
-shell_la_CPPFLAGS = -I @top_srcdir@/include $(READLINE_CFLAGS)
-shell_la_LIBADD = ../src/libcutlet.la $(READLINE_LIBS)
+shell_la_CPPFLAGS = -I @top_srcdir@/include
+shell_la_LIBADD = ../src/libcutlet.la
 shell_la_LDFLAGS = -module -avoid-version -shared
 
 debugger_la_SOURCES = debugger.cpp

--- a/libs/interactive.cpp
+++ b/libs/interactive.cpp
@@ -57,7 +57,7 @@
 extern "C" {
   DECLSPEC void init_cutlet(cutlet::interpreter *interp);
 
-  DECLSPEC std::istream &cmdline_stream();
+  DECLSPEC std::istream &interactive_stream();
 }
 
 namespace {
@@ -131,9 +131,9 @@ namespace {
     return cutlet::var<cutlet::string>("$ ");
   }
 
-  /************
-   * def exit *
-   ************/
+  /*********************
+   * def exit ¿result? *
+   *********************/
 
   cutlet::variable::pointer
   _iexit(cutlet::interpreter &interp, const cutlet::list &arguments) {
@@ -150,7 +150,7 @@ namespace {
       frame->done(cutlet::var<cutlet::list>(arguments));
       break;
     }
-    cmdline_stream().setstate(std::ios_base::eofbit);
+    interactive_stream().setstate(std::ios_base::eofbit);
 
     return nullptr;
   }
@@ -246,11 +246,11 @@ void init_cutlet(cutlet::interpreter *interp) {
   interp->add("exit", _iexit);
 }
 
-/******************
- * cmdline_stream *
- ******************/
+/**********************
+ * interactive_stream *
+ **********************/
 
-std::istream &cmdline_stream() {
+std::istream &interactive_stream() {
   // Create a singleton readline stream object for interactive use.
   static std::unique_ptr<std::istream> input = nullptr;
   static std::unique_ptr<std::streambuf> inputbuf = nullptr;

--- a/libs/interactive.cpp
+++ b/libs/interactive.cpp
@@ -1,0 +1,266 @@
+/*                                                                  -*- c++ -*-
+ * Copyright © 2023 Ron R Wills <ron@digitalcombine.ca>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* NOTE
+ *
+ * I've made the assumption that this would be loaded and used by a single
+ * interpreter. So only a single global reference is kept for the interpreter.
+ * Also readline functions are single global references that only expect a
+ * single interactive prompt. If any software uses more than one interpreter
+ * and expects to have each one interactive, it could get very messy.
+ *
+ * I'm sure this could all be made to work but it's not an issue for anyone
+ * right now so I'm moving on until it is.
+ *                                                                  - Ron Wills
+ */
+
+#include <cutlet>
+#include <cstring>
+#include <streambuf>
+#include <readline/readline.h>
+
+//#define DEBUG_INTERACTIVE 1
+
+#if DEBUG_INTERACTIVE
+#pragma message ("Interactive library debugging enabled")
+#include <iostream>
+#endif
+
+// We need to declare init_cutlet as a C function.
+extern "C" {
+  DECLSPEC void init_cutlet(cutlet::interpreter *interp);
+
+  DECLSPEC std::istream &cmdline_stream();
+}
+
+namespace {
+
+  /***********
+   * _interp *
+   ***********/
+
+
+  cutlet::interpreter *_interp(cutlet::interpreter *i_ptr = nullptr) {
+    // Keep a reference to the interpreter that loaded us.
+    static cutlet::interpreter *i = nullptr;
+    if (i_ptr) i = i_ptr;
+    return i;
+  }
+
+  /****************************
+   * component_name_generator *
+   ****************************/
+
+  char *component_name_generator(const char *text, int state) {
+    // Component name generator if readline auto completion.
+    static cutlet::sandbox::const_citerator iter, end;
+    static int len;
+
+    if (!state) {
+#if DEBUG_INTERACTIVE
+      std::cerr << "INTERACTIVE: Readline completion state reset" << std::endl;
+#endif
+      iter = _interp()->environment()->components().begin();
+      end = _interp()->environment()->components().end();
+      len = strlen(text);
+    }
+
+    while ((++iter != end)) {
+#if DEBUG_INTERACTIVE
+      std::cerr << "INTERACTIVE: " << iter->first << " == " << text << std::endl;
+#endif
+      if (iter->first.compare(0, len, text) == 0) {
+#if DEBUG_INTERACTIVE
+        std::cerr << "INTERACTIVE: match found" << std::endl;
+#endif
+        return strdup(iter->first.c_str());
+      }
+    }
+
+#if DEBUG_INTERACTIVE
+    std::cerr << "INTERACTIVE: no more matches" << std::endl;
+#endif
+    return nullptr;
+  }
+
+  /*****************************
+   * component_name_completion *
+   *****************************/
+
+  char **component_name_completion(const char *text, int start, int end) {
+    // Component name completion if readline auto completion.
+    rl_attempted_completion_over = 1;
+    return rl_completion_matches(text, component_name_generator);
+  }
+
+  /*********************
+   * def cutlet_prompt *
+   *********************/
+
+  cutlet::variable::pointer
+  _cutlet_prompt(cutlet::interpreter &interp, const cutlet::list &arguments) {
+    (void)interp;
+    (void)arguments;
+    return cutlet::var<cutlet::string>("$ ");
+  }
+
+  /************
+   * def exit *
+   ************/
+
+  cutlet::variable::pointer
+  _iexit(cutlet::interpreter &interp, const cutlet::list &arguments) {
+    cutlet::frame::pointer frame = interp.frame(1);
+
+    switch (arguments.size()) {
+    case 0:
+      frame->state(cutlet::frame::FS_DONE);
+      break;
+    case 1:
+      frame->done(arguments[0]);
+      break;
+    default:
+      frame->done(cutlet::var<cutlet::list>(arguments));
+      break;
+    }
+    cmdline_stream().setstate(std::ios_base::eofbit);
+
+    return nullptr;
+  }
+
+  /****************************************************************************
+   * class readlinebuf
+   */
+
+  class readlinebuf : public std::streambuf {
+    /* A stream buffer that uses the readline prompt/library as its input.
+     */
+  public:
+    readlinebuf();
+    virtual ~readlinebuf() noexcept;
+
+  protected:
+    virtual int_type underflow();
+
+  private:
+    std::string _linebuf;
+
+    bool oflush();
+  };
+
+  /****************************
+   * readlinebuf::readlinebuf *
+   ****************************/
+
+  readlinebuf::readlinebuf() {
+    // Setup the stream buffers.
+    setg(_linebuf.data(), _linebuf.data(), _linebuf.data());
+  }
+
+  /*****************************
+   * readlinebuf::~readlinebuf *
+   *****************************/
+
+  readlinebuf::~readlinebuf() noexcept {}
+
+  /**************************
+   * readlinebuf::underflow *
+   **************************/
+
+  readlinebuf::int_type readlinebuf::underflow() {
+    if (gptr() >= egptr()) {
+      // Get the prompt. A custom prompt can be created with the cutlet
+      // function cutlet_prompt.
+      std::string prompt = "$ ";
+      try {
+        prompt = *(_interp()->call("cutlet_prompt", cutlet::list()));
+      } catch (std::exception &err) {
+#if DEBUG_INTERACTIVE
+        std::cerr << "DEBUG: Error calling cutlet_prompt "
+                  << err.what() << std::endl;
+#endif
+      }
+
+      // The buffer has been exhausted, read more in from readline.
+      char *line = readline(prompt.c_str());
+
+      if (line == nullptr) {
+        // End of file
+#ifdef DEBUG_NSTREAM
+        std::clog << "sockbuf::underflow eof" << std::endl;
+#endif
+        return traits_type::eof();
+      }
+
+      // Update the the buffer and free allocated strings from readline.
+      _linebuf = line;
+      _linebuf += '\n';
+      free(line);
+
+      // Update the buffer.
+      setg(_linebuf.data(), _linebuf.data(),
+           _linebuf.data() + _linebuf.size());
+    }
+
+    // Return the next character.
+    return traits_type::to_int_type(*gptr());
+  }
+}
+
+/***************
+ * init_cutlet *
+ ***************/
+
+void init_cutlet(cutlet::interpreter *interp) {
+  // Add the library to the interpreter. We also keep our own reference to the
+  // interpreter for the command line stream buffer if needed.
+  _interp(interp);
+  interp->add("cutlet_prompt", _cutlet_prompt);
+  interp->add("exit", _iexit);
+}
+
+/******************
+ * cmdline_stream *
+ ******************/
+
+std::istream &cmdline_stream() {
+  // Create a singleton readline stream object for interactive use.
+  static std::unique_ptr<std::istream> input = nullptr;
+  static std::unique_ptr<std::streambuf> inputbuf = nullptr;
+
+  if (not input) {
+    rl_attempted_completion_function = component_name_completion;
+
+    inputbuf = std::make_unique<readlinebuf>();
+    input = std::make_unique<std::istream>(inputbuf.get());
+  }
+
+  return *input;
+}

--- a/libs/shell.cpp
+++ b/libs/shell.cpp
@@ -314,7 +314,7 @@ namespace {
   const std::regex re_redir_out("([0-9]+|&)?>([0-9]+|>)?");
   const std::regex re_redir_in("([0-9]+)?<");
 
-  // def exec command
+  // def sh command
   cutlet::variable::pointer _eval(cutlet::interpreter &interp,
                                   const cutlet::list &parameters) {
     (void)interp;
@@ -328,7 +328,7 @@ namespace {
     end++;
 
     // Build the commands and the pipes.
-    for (;end != parameters.end(); end++) {
+    for (; end != parameters.end(); end++) {
       std::smatch iomtch;
       std::string bit((std::string)(**end));
 
@@ -457,9 +457,10 @@ namespace {
     for (auto &cmd: commands) delete cmd;
 
     return std::make_shared<cutlet::string>(status);
+    //return nullptr;
   }
 
-  // def env variable ¿=? ¿value?
+  // def export variable ¿¿=? value?
   cutlet::variable::pointer _export(cutlet::interpreter &interp,
                                     const cutlet::list &parameters) {
     (void)interp;
@@ -473,11 +474,12 @@ namespace {
                cutlet::primative<std::string>(parameters[0]) :
                "")
            << " (1 <= " << p_count
-           << " <= 3).\n environ variable ¿=? ¿value?";
+           << " <= 3).\n export variable ¿¿=? value?";
       throw std::runtime_error(mesg.str());
     }
 
     if (p_count == 1) {
+      // Return the value of the environment variable
 #ifdef HAVE_SECURE_GETENV
       char *res =
         secure_getenv(cutlet::primative<std::string>(parameters[0]).c_str());
@@ -488,13 +490,14 @@ namespace {
       return std::make_shared<cutlet::string>(res);
 
     } else {
+      // Set the value of an environment variable.
       cutlet::variable::pointer value = parameters[1];
 
       if (p_count == 3) {
         if (cutlet::primative<std::string>(value) != "=") {
           std::stringstream mesg;
           mesg << "Invalid token " << cutlet::primative<std::string>(value)
-               << " for environ\n environ variable ¿=? ¿value?";
+               << " for environ\n export variable ¿¿=? value?";
           throw std::runtime_error(mesg.str());
         }
 
@@ -513,6 +516,9 @@ namespace {
 
     return nullptr;
   }
+
+  /****************************************************************************
+   */
 
   class editbuf : public std::streambuf {
   public:

--- a/man/interactive.3cutlet
+++ b/man/interactive.3cutlet
@@ -1,0 +1,75 @@
+.\" Copyright © 2018 Ron R Wills <ron@digitalcombine.ca>
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions are met:
+.\"
+.\" 1. Redistributions of source code must retain the above copyright notice,
+.\"    this list of conditions and the following disclaimer.
+.\"
+.\" 2. Redistributions in binary form must reproduce the above copyright
+.\"    notice,this list of conditions and the following disclaimer in the
+.\"    documentation and/or other materials provided with the distribution.
+.\"
+.\" 3. Neither the name of the copyright holder nor the names of its
+.\"    contributors may be used to endorse or promote products derived from
+.\"    this software without specific prior written permission.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+.\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.\" ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+.\" LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+.\" CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+.\" SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+.\" INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+.\" CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+.\" ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+.\" POSSIBILITY OF SUCH DAMAGE.
+.\"
+.Dd March 13, 2024
+.Dt INTERACTIVE 3CUTLET
+.Os
+.Sh NAME
+.Nm interactive
+.Nd adds an interactive input and prompt to the cutlet interpreter
+.Sh SYNOPSIS
+.Ic import Ar interactive
+.Pp
+.Bl -inset -compact
+.It Ic def Ar cutlet_prompt
+.It Ic def Ar exit Op result
+.It Ft std::istream& Fn interactive_stream
+.El
+.Sh DESCRIPTION
+The
+.Nm
+library is automatically loaded when the cutlet detects that it is running on a
+tty.
+It uses the readline library for the interactive command prompt.
+.Bl -tag -width Ds
+.It Ic def Ar cutlet_prompt
+This function is called every time the prompt is displayed, its
+return value being used as the prompt.
+It can be redefined to provide custom information within the prompt.
+.It Ic def Ar exit Op result
+This function exits the interpreter.
+The optional return value,
+.Ar result ,
+should be an integer that will be returned to shell.
+If
+.Ar result
+is not set it returns 0 by default.
+.It Ft std::istream& Fn interactive_stream
+This returns the c++ input stream that uses the readline library for interactive
+use.
+Example use of the c++ API:
+.Pp
+.Bd -literal -compact
+std::function<std::istream &()> interactive_stream =
+  interpreter.symbol<std::istream &(*)()>("interactive_stream");
+std::istream &in = interactive_stream();
+.Ed
+.El
+.Sh AUTHORS
+.An Ron Wills
+.Mt <ron@digitalcombine.ca>

--- a/src/cutlet.cpp
+++ b/src/cutlet.cpp
@@ -1368,7 +1368,7 @@ void cutlet::interpreter::import(const std::string &library_name) {
 void cutlet::interpreter::entry() {
   auto ast_tree = std::make_shared<ast::block>();
 
-  while (tokens or not tokens->expect(parser::tokenizer::T_EOF)) {
+  while (tokens and not tokens->expect(parser::tokenizer::T_EOF)) {
 
     // Remove empty lines.
     while (tokens->expect(cutlet::T_EOL)) tokens->next();

--- a/tests/shell.cutlet
+++ b/tests/shell.cutlet
@@ -28,6 +28,6 @@
 
 import shell
 
-eval ls -1 > filelist.txt
-eval ls -1 | wc -l >> filelist.txt
-eval sort < filelist.txt
+sh ls -1 > filelist.txt
+sh ls -1 | wc -l >> filelist.txt
+sh sort < filelist.txt


### PR DESCRIPTION
Allow the cutlet interpreter to be used interactively.
The library interactive is automatically loaded when the cutlet binary is run on a tty.